### PR TITLE
feat: set hostname (controlplane/node01) on nodes during fase1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,13 @@ fase1: ## Instala containerd, kubeadm, kubelet e kubectl em todos os nós
 	CONTROL_IP=$$(terraform output -json public_ips | jq -r '.[0]'); \
 	WORKER_IPS=$$(terraform output -json public_ips | jq -r '.[1:][]'); \
 	echo "==> [fase1] Configurando controlplane ($$CONTROL_IP)..."; \
-	$(SSH)$$CONTROL_IP 'sudo bash -s' < scripts/fase1-node.sh; \
+	$(SSH)$$CONTROL_IP 'sudo bash -s controlplane' < scripts/fase1-node.sh; \
+	INDEX=1; \
 	for ip in $$WORKER_IPS; do \
-		echo "==> [fase1] Configurando worker ($$ip)..."; \
-		$(SSH)$$ip 'sudo bash -s' < scripts/fase1-node.sh; \
+		WORKER_NAME=$$(printf "node%02d" $$INDEX); \
+		echo "==> [fase1] Configurando worker ($$ip) como $$WORKER_NAME..."; \
+		$(SSH)$$ip "sudo bash -s $$WORKER_NAME" < scripts/fase1-node.sh; \
+		INDEX=$$((INDEX + 1)); \
 	done; \
 	echo "==> Fase 1 concluída em todos os nós!"
 

--- a/scripts/fase1-node.sh
+++ b/scripts/fase1-node.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+NODE_HOSTNAME="${1:-}"
+if [ -n "$NODE_HOSTNAME" ]; then
+  echo "==> [fase1] Configurando hostname para $NODE_HOSTNAME..."
+  hostnamectl set-hostname "$NODE_HOSTNAME"
+fi
+
 echo "==> [fase1] Atualizando pacotes..."
 apt-get update -y
 


### PR DESCRIPTION
## Summary

- `scripts/fase1-node.sh` now accepts the hostname as `$1` and runs `hostnamectl set-hostname` at the start
- `Makefile` passes `controlplane` to the first node and `node01`, `node02`... to workers via `sudo bash -s <hostname>`
- On the next `make full`, nodes will register in the cluster with proper names instead of the AWS-generated `ip-10-20-1-x` hostnames

## Test plan

- [ ] Run `make full` and confirm `kubectl get nodes` shows `controlplane` and `node01`
- [ ] Confirm `kubectl describe node controlplane` shows correct hostname