### PR TITLE
docs: improve CLAUDE.md with full workflow and correct instance naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,40 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Purpose
 
-Terraform infrastructure for CKA (Certified Kubernetes Administrator) study lab on AWS. Creates EC2 instances pre-configured for manual Kubernetes cluster setup via kubeadm.
+Terraform infrastructure for CKA (Certified Kubernetes Administrator) study lab on AWS. Creates EC2 instances and a Makefile-driven workflow to bootstrap a multi-node Kubernetes cluster via kubeadm + Cilium.
+
+## Typical Workflow
+
+```bash
+# 1. Provision infrastructure
+terraform apply -auto-approve -var="key_name=cka-key"
+
+# 2. Install Kubernetes packages on all nodes (containerd, kubeadm, kubelet, kubectl)
+make fase1 KEY=~/workspace/cka-key.pem
+
+# 3. Init controlplane, install Cilium CNI, join workers
+make fase2 KEY=~/workspace/cka-key.pem
+
+# Or run both phases at once
+make full KEY=~/workspace/cka-key.pem
+
+# 4. Pull kubeconfig locally
+make kubeconfig KEY=~/workspace/cka-key.pem
+export KUBECONFIG=~/workspace/cka-kubeconfig.yaml
+```
+
+**Local prerequisite**: `jq` must be installed — the Makefile uses it to parse `terraform output -json public_ips`.
 
 ## Terraform Commands
 
 ```bash
-# Initialize (first time or after provider changes)
-terraform init
-
-# Preview changes
+terraform init                                    # first time or after provider changes
 terraform plan -var="key_name=cka-key"
-
-# Apply infrastructure
 terraform apply -auto-approve -var="key_name=cka-key"
-
-# Destroy all resources
 terraform destroy -auto-approve -var="key_name=cka-key"
 ```
 
-The `key_name` variable is required (no default). SSH key must be pre-created in AWS `us-east-1`:
+`key_name` is required (no default). SSH key must be pre-created in `us-east-1`:
 
 ```bash
 aws ec2 create-key-pair --key-name cka-key --region us-east-1 --query 'KeyMaterial' --output text > ~/workspace/cka-key.pem
@@ -31,19 +46,20 @@ chmod 400 ~/workspace/cka-key.pem
 
 ## Architecture
 
-All resources live in a single VPC (`10.20.0.0/16`) with one public subnet (`10.20.1.0/24`) in `us-east-1`. The layout is flat:
+All resources live in a single VPC (`10.20.0.0/16`) with one public subnet (`10.20.1.0/24`) in `us-east-1`:
 
-- `provider.tf` — AWS provider config
-- `versions.tf` — Terraform + provider version constraints
-- `data.tf` — AMI lookup (Ubuntu 22.04 LTS) + `local.my_ip` via `checkip.amazonaws.com`
+- `data.tf` — AMI lookup (Ubuntu 22.04 LTS via SSM) + `local.my_ip` via `checkip.amazonaws.com`
 - `main.tf` — all resources: VPC, IGW, subnet, route table, security group, EC2 instances
-- `variables.tf` — input variables
-- `outputs.tf` — public IPs and ready-to-use SSH commands
+- `variables.tf` / `outputs.tf` — inputs and outputs
+- `scripts/fase1-node.sh` — runs on every node: sets hostname, disables swap, configures kernel modules/sysctl, installs containerd + k8s packages v1.31
+- `scripts/fase2-control.sh` — runs only on controlplane: `kubeadm init`, Cilium install, prints join command to stdout (all other output goes to stderr — the Makefile captures stdout as `JOIN_CMD`)
 
 ## Key Design Decisions
 
-**Dynamic SSH CIDR**: `data.tf` auto-detects the caller's public IP via `https://checkip.amazonaws.com` and stores it as `local.my_ip`. The security group uses `var.allowed_ssh_cidr` if set, otherwise falls back to `"${local.my_ip}/32"`. Passing `allowed_ssh_cidr=0.0.0.0/0` disables this auto-restriction.
+**Dynamic SSH CIDR**: The security group uses `var.allowed_ssh_cidr` if set, otherwise auto-detects your IP (`local.my_ip/32`). The same CIDR also allows access to port 6443 (Kubernetes API) and NodePort range 30000-32767.
 
-**Instance count**: Controlled by `var.instances` (default: 2). Instances are named `cka-lab-node-01`, `cka-lab-node-02`, etc. The first node becomes the control plane; remaining nodes are workers.
+**Instance naming**: Instances use Tag `Name`: `controlplane` (index 0) and `node01`, `node02`, … (index 1+). The Makefile reads `public_ips[0]` as the controlplane and `public_ips[1:]` as workers.
 
-**No user_data**: Kubernetes components (containerd, kubeadm, kubelet, kubectl v1.31) are installed manually via SSH after provisioning. Setup steps are documented in `README.md`.
+**Hostname injection**: `fase1-node.sh` accepts the hostname as `$1`. The Makefile passes `controlplane` or `nodeNN` so hostnames match Kubernetes node names.
+
+**kubeconfig for local access**: `make kubeconfig` copies `/home/ubuntu/.kube/config`, rewrites the server URL from private IP to public IP, and sets `insecure-skip-tls-verify=true` (required because the cert is generated with the private IP as SAN, not the public IP).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ systemctl status kubelet
 # Inicializar o cluster (executar apenas no nó master)
 kubeadm init
 
-# Configurar kubectl para o usuário ubuntu
+# Configurar kubectl para o usuári
 mkdir -p $HOME/.kube
 cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 chown $(id -u):$(id -g) $HOME/.kube/config
@@ -216,7 +216,9 @@ cilium status
 cilium install
 
 ```
-
+  "controlplane" = "ssh -i <path-da-sua-chave.pem> ubuntu@13.223.224.254"
+  "node01" = "ssh -i <path-da-sua-chave.pem> ubuntu@3.228.11.131"
+  
 ### 4. Adicionar Worker Nodes (nos demais nós)
 
 ```bash

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,10 @@ output "public_ips" {
 }
 
 output "private_ips" {
-  value = [for i in aws_instance.nodes : i.private_ip]
+  value = {
+    for i in aws_instance.nodes :
+    i.tags["Name"] => i.private_ip
+  }
 }
 
 output "nodes" {


### PR DESCRIPTION
## Summary

- Add **Typical Workflow** section to CLAUDE.md showing the full `terraform apply → make fase1 → make fase2 → make kubeconfig` sequence (previously undocumented)
- Fix incorrect instance naming: instances are tagged `controlplane`/`node01` not `cka-lab-node-01`
- Document `scripts/fase1-node.sh` and `fase2-control.sh` responsibilities, including the stdout/stderr split that the Makefile relies on to capture the `kubeadm join` command
- Note that the security group also opens port 6443 (Kubernetes API) and NodePort range 30000-32767, not just SSH
- Change `private_ips` Terraform output from a list to a `name => ip` map for easier lookup

## Test plan

- [ ] Verify `terraform plan` still works cleanly after `outputs.tf` change
- [ ] Confirm the Typical Workflow in CLAUDE.md matches what `make help` and Makefile targets actually do